### PR TITLE
Add appveyor testing for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 0.0.{build}
+environment:
+  matrix:
+    - nodejs_version: "8"
+image:
+  - Visual Studio 2017
+  - Visual Studio 2015
+  - Visual Studio 2013
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  # Prepend 2017, 2015 and 2013 tools. Harmless when the path for the other versions don't exist.
+  - set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%ProgramFiles(x86)%\MSBuild\14.0\Bin;%ProgramFiles(x86)%\MSBuild\12.0\Bin;%PATH%"
+  # Upgrade npm to latest
+  - npm install --loglevel error -g npm 
+  - set "PATH=%APPDATA%\npm;%PATH%"
+  - node -v
+  - npm -v
+  - npm install -g --loglevel error node-gyp
+  - npm install
+build: off
+test_script:
+  - cmd: npm test


### PR DESCRIPTION
Adds AppVeyor testing for MSVS 2013, 2015 and 2017.

If you want to merge this, you'll need to enable this GitHub repo in AppVeyor. Here's what the build looks like with my fix in #66: https://ci.appveyor.com/project/zbjornson/sse4-crc32/build/0.0.4