### PR TITLE
Fix NodeJS 10 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     - g++-4.8
 language: node_js
 node_js:
+  - "10"
   - "9"
   - "8"
   - "6"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "./sse4_crc32",
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "2.8.0"
+    "nan": "2.11.0"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/src/crc32c.cpp
+++ b/src/crc32c.cpp
@@ -221,9 +221,9 @@ NAN_METHOD(calculateCrc) {
         Local<String> strInput = info[1]->ToString();
 
         if (useHardwareCrc) {
-            crc = hwCrc32c(initCrc, (const char *)(*String::Utf8Value(strInput)), (size_t)strInput->Utf8Length());
+            crc = hwCrc32c(initCrc, (const char *)(*Nan::Utf8String(strInput)), (size_t)strInput->Utf8Length());
         } else {
-            crc = swCrc32c(initCrc, (const char *)(*String::Utf8Value(strInput)), (size_t)strInput->Utf8Length());
+            crc = swCrc32c(initCrc, (const char *)(*Nan::Utf8String(strInput)), (size_t)strInput->Utf8Length());
         }
     }
 


### PR DESCRIPTION
I realize the plan is to move to N-API. This change is a stop gap to address the deprecation warnings when installing sse4_crc32 using Node 10.