### PR TITLE
Node 12 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ addons:
     - g++-4.8
 language: node_js
 node_js:
+  - "12"
   - "10"
   - "9"
   - "8"
   - "6"
-  - "4"
-  - "0.12"
-  - "0.10"
 before_install:
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
 notifications:

--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
     "url": "https://github.com/anandsuresh/sse4_crc32/issues"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=5.10.0"
   },
   "main": "./sse4_crc32",
   "dependencies": {
-    "bindings": "~1.2.1",
-    "nan": "2.11.0"
+    "bindings": "~1.5.0",
+    "nan": "2.14.0"
   },
   "devDependencies": {
     "chai": "^2.0.0",
     "crc32": "^0.2.1",
     "mocha": "^2.1.0",
-    "node-gyp": "^3.3.1"
+    "node-gyp": "^5.0.3"
   },
   "scripts": {
     "test": "mocha test/*test.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sse4.2",
     "error detection"
   ],
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "Anand Suresh <anandsuresh@gmail.com> (https://github.com/anandsuresh)",
   "license": "MIT",
   "repository": {

--- a/src/crc32c.cpp
+++ b/src/crc32c.cpp
@@ -192,7 +192,7 @@ NAN_METHOD(calculateCrc) {
         Nan::ThrowTypeError("useHardwareCrc isn't a boolean value as expected!");
         return;
     }
-    useHardwareCrc = info[0]->BooleanValue();
+    useHardwareCrc = Nan::To<bool>(info[0]).FromMaybe(false);
 
     // Check for any initial CRC passed to the function
     if (info.Length() > 2) {
@@ -200,14 +200,14 @@ NAN_METHOD(calculateCrc) {
             Nan::ThrowTypeError("Initial CRC-32C is not an integer value as expected!");
             return;
         }
-        initCrc = info[2]->Uint32Value();
+        initCrc = Nan::To<uint32_t>(info[2]).FromMaybe(0);
     } else {
         initCrc = 0;
     }
 
     // Ensure the argument is a buffer or a string
     if (node::Buffer::HasInstance(info[1])) {
-        Local<Object> buf = info[1]->ToObject();
+        Local<Object> buf = Nan::To<v8::Object>(info[1]).ToLocalChecked();
 
         if (useHardwareCrc) {
             crc = hwCrc32c(initCrc, (const char *)Buffer::Data(buf), (size_t)Buffer::Length(buf));
@@ -218,12 +218,12 @@ NAN_METHOD(calculateCrc) {
         Nan::ThrowTypeError("Cannot compute CRC-32C for objects!");
         return;
     } else {
-        Local<String> strInput = info[1]->ToString();
+        Local<String> strInput = Nan::To<String>(info[1]).ToLocalChecked();
 
         if (useHardwareCrc) {
-            crc = hwCrc32c(initCrc, (const char *)(*Nan::Utf8String(strInput)), (size_t)strInput->Utf8Length());
+            crc = hwCrc32c(initCrc, (const char *)(*Nan::Utf8String(strInput)), (size_t)Nan::Utf8String(strInput).length());
         } else {
-            crc = swCrc32c(initCrc, (const char *)(*Nan::Utf8String(strInput)), (size_t)strInput->Utf8Length());
+            crc = swCrc32c(initCrc, (const char *)(*Nan::Utf8String(strInput)), (size_t)Nan::Utf8String(strInput).length());
         }
     }
 

--- a/test/sse4_crc32.test.js
+++ b/test/sse4_crc32.test.js
@@ -19,7 +19,7 @@ describe('Sse4Crc32', function() {
                 output: 3039989317
             },
             'buffer': {
-                input : new Buffer('SSE4-CRC32: A hardware accelerated CRC32 implementation for node.js'),
+                input : new Buffer.from('SSE4-CRC32: A hardware accelerated CRC32 implementation for node.js'),
                 output: 3039989317
             }
         };

--- a/test/sse4_crc32.test.js
+++ b/test/sse4_crc32.test.js
@@ -19,7 +19,7 @@ describe('Sse4Crc32', function() {
                 output: 3039989317
             },
             'buffer': {
-                input : new Buffer.from('SSE4-CRC32: A hardware accelerated CRC32 implementation for node.js'),
+                input : Buffer.from('SSE4-CRC32: A hardware accelerated CRC32 implementation for node.js'),
                 output: 3039989317
             }
         };


### PR DESCRIPTION
This isn't in place of the work to move to N-API. This is simply to address the breaking changes in NodeJS 12 with respect to NAN.

I should note that this change does drop support for Node versions below 6 due to changes in Node-GYP. Those versions are now long out of LTS support. 

* Migrate to new NaN APIs
* Use new Buffer API to avoid NodeJS deprecated warnings
* Upgrade NaN, Node-GYP and bindings versions.
* Bump package version to 5.4

Fixes #74