### PR TITLE
Fix random length buffer generator to round off the buffer size

### DIFF
--- a/benchmark/multiple_random_size_buffers.benchmark.js
+++ b/benchmark/multiple_random_size_buffers.benchmark.js
@@ -25,7 +25,7 @@ const BUFFERS = []
  */
 function initBuffers (benchmark) {
   for (i = 0; i < benchmark.iterations; i++) {
-    const len = Math.random() * 65536
+    const len = Math.floor(Math.random() * 65536)
     const buf = Buffer.alloc(len)
 
     let j = 0


### PR DESCRIPTION
The generator was failing to `Math.floor()` the random length, causing issues on node v12.

Fixes #77 